### PR TITLE
Transform traffic controls along with lanelets

### DIFF
--- a/crdesigner/map_conversion/opendrive/opendrive_conversion/network.py
+++ b/crdesigner/map_conversion/opendrive/opendrive_conversion/network.py
@@ -265,7 +265,7 @@ class Network:
                     self._stop_lines.append(stop_line)
 
     def export_lanelet_network(
-        self, transformer: Transformer, filter_types: Optional[List[str]] = None
+        self, transformer: Optional[Transformer], filter_types: Optional[List[str]] = None
     ) -> LaneletNetwork:
         """Export network as lanelet network.
 

--- a/crdesigner/map_conversion/opendrive/opendrive_conversion/network.py
+++ b/crdesigner/map_conversion/opendrive/opendrive_conversion/network.py
@@ -318,6 +318,18 @@ class Network:
 
         self.relate_crosswalks_to_intersection(lanelet_network)
 
+        # Apply the transformer to traffic controls
+        # TODO: copy objects instead of modifying them in place
+        for xs in [
+            self._traffic_lights,
+            self._traffic_signs,
+        ]:
+            for x in xs:
+                x.position = np.array(transformer.transform(*x.position))
+        for x in self._stop_lines:
+            x.start = np.array(transformer.transform(*x.start))
+            x.end = np.array(transformer.transform(*x.end))
+
         # Assign traffic signals, lights and stop lines to lanelet network
         lanelet_network.add_traffic_lights_to_network(self._traffic_lights)
         lanelet_network.add_traffic_signs_to_network(self._traffic_signs)

--- a/crdesigner/map_conversion/opendrive/opendrive_conversion/network.py
+++ b/crdesigner/map_conversion/opendrive/opendrive_conversion/network.py
@@ -318,17 +318,17 @@ class Network:
 
         self.relate_crosswalks_to_intersection(lanelet_network)
 
-        # Apply the transformer to traffic controls
-        # TODO: copy objects instead of modifying them in place
-        for xs in [
-            self._traffic_lights,
-            self._traffic_signs,
-        ]:
-            for x in xs:
-                x.position = np.array(transformer.transform(*x.position))
-        for x in self._stop_lines:
-            x.start = np.array(transformer.transform(*x.start))
-            x.end = np.array(transformer.transform(*x.end))
+        if transformer is not None:
+            # Apply the transformer to traffic controls
+            for xs in [
+                self._traffic_lights,
+                self._traffic_signs,
+            ]:
+                for x in xs:
+                    x.position = np.array(transformer.transform(*x.position))
+            for x in self._stop_lines:
+                x.start = np.array(transformer.transform(*x.start))
+                x.end = np.array(transformer.transform(*x.end))
 
         # Assign traffic signals, lights and stop lines to lanelet network
         lanelet_network.add_traffic_lights_to_network(self._traffic_lights)


### PR DESCRIPTION
I noticed that the transform wasn't being applied to the traffic controls when exporting the network, resulting in them being placed away from the map when a custom transformer is used. This fixes the problem for my use case, but I wasn't sure what's the proper way to do the fix, in particular how to copy the traffic control objects.