### PR TITLE
fix(lanelet2cr): correct traffic light coordinate transform order

### DIFF
--- a/crdesigner/map_conversion/lanelet2/lanelet2cr.py
+++ b/crdesigner/map_conversion/lanelet2/lanelet2cr.py
@@ -563,7 +563,7 @@ class Lanelet2CRConverter:
         node = self.osm.nodes[traffic_light_way.nodes[1]]
 
         # convert to CR space
-        x, y = self.transformer.transform(node.lon, node.lat)
+        x, y = self.transformer.transform(node.lat, node.lon)
         x -= self.origin_utm[0]
         y -= self.origin_utm[1]
 


### PR DESCRIPTION
## Summary
This PR fixes `lanelet2cr` traffic light positions becoming `inf` in converted CommonRoad maps.

## Root cause
In traffic light conversion, coordinate transform arguments were reversed:
- before: `transform(node.lon, node.lat)`
- expected (and used in other conversion paths): `transform(node.lat, node.lon)`

This could pass longitude (~139) as latitude, causing projection overflow and resulting in `<x>inf</x>`, `<y>inf</y>`.

## Changes
- Updated one line in `Lanelet2CRConverter.traffic_light_conversion`:
  - [crdesigner/map_conversion/lanelet2/lanelet2cr.py:566](/home/h-kawai/map_conversion/commonroad-scenario-designer/crdesigner/map_conversion/lanelet2/lanelet2cr.py:566)

## Validation
- Re-ran lanelet2 -> CommonRoad conversion on a map that reproduced the issue.
- Confirmed traffic light coordinates are now finite (`<x>inf</x>`, `<y>inf</y>` no longer appear).

Fixes #49
