### PR TITLE
Fix left-hand-traffic (LHT) lane conversion in OpenDRIVE-to-CommonRoad.

### DIFF
--- a/crdesigner/map_conversion/common/conversion_lanelet_network.py
+++ b/crdesigner/map_conversion/common/conversion_lanelet_network.py
@@ -538,7 +538,7 @@ class ConversionLaneletNetwork(LaneletNetwork):
                 if adj_right.successor[0] != successor.adj_right:
                     return False
             else:
-                if not lanelet.has_unique_pred_succ_relation(-1, adj_right):
+                if not self.has_unique_pred_succ_relation(-1, adj_right):
                     return False
                 if adj_right.predecessor[0] != successor.adj_right:
                     return False

--- a/crdesigner/map_conversion/opendrive/odr2cr/opendrive_conversion/network.py
+++ b/crdesigner/map_conversion/opendrive/odr2cr/opendrive_conversion/network.py
@@ -421,6 +421,26 @@ class Network:
         # Perform lane splits and joins
         lanelet_network.join_and_split_possible_lanes()
 
+        # LHT fix-up: calc_vertices and join_and_split both use the OpenDrive
+        # inner/outer convention (inner -> left_vertices, outer -> right_vertices).
+        # By reflection symmetry that matches physical-left / physical-right for
+        # RHT lanes but is reversed for LHT lanes. Swap them here, after
+        # join_and_split has run, so its RHT-centric geometry computation is
+        # preserved. adj_left / adj_right pointers are set with LHT awareness in
+        # ParametricLaneGroup._set_adjacent_lanes and do not need to be touched.
+        for lanelet in lanelet_network.lanelets:
+            plg = getattr(lanelet, "parametric_lane_group", None)
+            if plg is None or plg.driving_direction:
+                continue
+            lanelet.left_vertices, lanelet.right_vertices = (
+                lanelet.right_vertices,
+                lanelet.left_vertices,
+            )
+            lanelet.line_marking_left_vertices, lanelet.line_marking_right_vertices = (
+                lanelet.line_marking_right_vertices,
+                lanelet.line_marking_left_vertices,
+            )
+
         lanelet_network.convert_all_lanelet_ids()
         self._link_index.update_intersection_lane_id(lanelet_network.old_lanelet_ids())
         # self.traffic_signal_elements.update_traffic_signs_map_lane_id(lanelet_network.old_lanelet_ids())

--- a/crdesigner/map_conversion/opendrive/odr2cr/opendrive_conversion/plane_elements/plane_group.py
+++ b/crdesigner/map_conversion/opendrive/odr2cr/opendrive_conversion/plane_elements/plane_group.py
@@ -395,44 +395,17 @@ class ParametricLaneGroup:
                 adjacent_width = np.linalg.norm(adj_inner_pos - adj_outer_pos)
                 local_width_offset = distance_slope * pos + global_distance[0]
 
-                if mirror_border == "left":
-                    new_outer_pos = self.calc_border("inner", pos, local_width_offset)[0]
-                    modified_width = np.linalg.norm(new_outer_pos - inner_pos)
-
-                    # change width s.t. it does not mirror inner border but instead
-                    # outer border
-                    local_width_offset = (
-                        math.copysign(1, local_width_offset) * last_width_difference
-                    )
-                    if modified_width < original_width:
-                        new_vertex = self.calc_border("outer", pos, local_width_offset)[0]
-                        if transformer is not None:
-                            right_vertices.append(
-                                transformer.transform(new_vertex[0], new_vertex[1])
-                            )
-                        else:
-                            right_vertices.append(new_vertex)
-                    elif modified_width > original_width + adjacent_width:
-                        if transformer is not None:
-                            right_vertices.append(
-                                transformer.transform(adj_outer_pos[0], adj_outer_pos[1])
-                            )
-                        else:
-                            right_vertices.append(adj_outer_pos)
-                    else:
-                        if transformer is not None:
-                            right_vertices.append(
-                                transformer.transform(new_outer_pos[0], new_outer_pos[1])
-                            )
-                        else:
-                            right_vertices.append(new_outer_pos)
-                        last_width_difference = abs(modified_width - original_width)
-
-                    if transformer is not None:
-                        left_vertices.append(transformer.transform(inner_pos[0], inner_pos[1]))
-                    else:
-                        left_vertices.append(inner_pos)
-                elif mirror_border == "right":
+                # Both "left" and "right" mirror_border cases use the
+                # lanelet's own outer polynomial (which carries the width
+                # taper) to compute ``new_inner``, store it in
+                # ``left_vertices``, and keep ``right_vertices`` at the
+                # natural outer position. With a constant offset equal to
+                # adj_width, the varying polyval produces a constant-width
+                # overlap with the adjacent lane at the zero-width end. For
+                # LHT (reversed) lanes the physical-left / physical-right
+                # assignment is corrected by the swap pass in
+                # ``network.py`` after JOIN/SPLIT has run.
+                if mirror_border == "left" or mirror_border == "right":
                     new_inner_pos = self.calc_border("outer", pos, local_width_offset)[0]
                     modified_width = np.linalg.norm(new_inner_pos - outer_pos)
 


### PR DESCRIPTION
  ## Overview                                                                                                                                                                                               
                                                                                                                                                                                                            
  Fixes incorrect lane geometry and adjacency when converting OpenDRIVE maps that contain left-hand-traffic (LHT) roads (e.g., UK, Japan, Australia). Previously, LHT lanes ended up with physical-left and 
  physical-right vertices swapped after conversion, which produced visually mirrored lanelets and broke downstream consumers (e.g., Lanelet2 export for Autoware ODD testing).                              
                                                                                                                                                                              
  ## Motivation                                                                                                                                                                                             
                                                                                                                                                                                                          
  `calc_vertices` and `join_and_split_possible_lanes` use the OpenDRIVE inner/outer convention (inner → `left_vertices`, outer → `right_vertices`). By reflection symmetry, that mapping matches
  physical-left/physical-right for RHT lanes but is reversed for LHT lanes. As a result, LHT lanelets came out with their left and right boundaries swapped, and the asymmetric `mirror_border == "left"`   
  vs. `"right"` branches in `ParametricLaneGroup.calc_vertices` produced inconsistent geometry across mirrored neighbours.                                                                               
                                                                                                                                                                                                            
  There was also a typo in `ConversionLaneletNetwork._check_concatenation_with_adjacent`: it called `lanelet.has_unique_pred_succ_relation(...)` instead of `self.has_unique_pred_succ_relation(...)`, which
   raised an `AttributeError` on LHT maps that exercised the `adj_right` branch.                                                                                                                            
                                                                                
  ## Changes                                                                                                                                                                                                
                                                                                                                                                                                                          
  - **Post-join LHT swap** (`network.py`): after `join_and_split_possible_lanes`, swap `left_vertices`/`right_vertices` and `line_marking_left_vertices`/`line_marking_right_vertices` for any lanelet whose
   `parametric_lane_group.driving_direction` is False (LHT). `adj_left`/`adj_right` are already set correctly in `ParametricLaneGroup._set_adjacent_lanes` and are left untouched.                          
  - **Unify mirror_border branches** (`plane_group.py`): collapse the two asymmetric `if mirror_border == "left"` / `elif mirror_border == "right"` branches into a single branch that always uses the 
  lanelet's own outer polynomial to compute `new_inner`. This produces a consistent constant-width overlap with the adjacent lane at the zero-width end; the LHT physical-left/right correction is then     
  handled by the swap pass above.                                                                                                                                                                           
  - **Fix `AttributeError` on adj_right concatenation check** (`conversion_lanelet_network.py`): change `lanelet.has_unique_pred_succ_relation(...)` to `self.has_unique_pred_succ_relation(...)` (it is a
  method on `ConversionLaneletNetwork`, not on `Lanelet`).                                                                                                                                                  
                                                                                                                                                                                                            
  ## Files Modified
                                                                                                                                                                                                            
  - `crdesigner/map_conversion/common/conversion_lanelet_network.py` (+1, −1)
  - `crdesigner/map_conversion/opendrive/odr2cr/opendrive_conversion/network.py` (+20)                                                                                                                      
  - `crdesigner/map_conversion/opendrive/odr2cr/opendrive_conversion/plane_elements/plane_group.py` (+11, −38)